### PR TITLE
Update Ladybug_Export Ladybug - .ghuser folder path

### DIFF
--- a/src/Ladybug_Export Ladybug.py
+++ b/src/Ladybug_Export Ladybug.py
@@ -32,7 +32,8 @@ import shutil
 import os
 import uuid
 
-UOFolder = "C:\\Users\\" + os.getenv("USERNAME") + "\\AppData\\Roaming\\Grasshopper\\UserObjects\\"
+UOFolder = gh.GH_ComponentServer.GHUser_AppDataDirectory
+UOFolder = UOFolder.replace("\\", "\\\\")
 cs = gh.GH_ComponentServer()
 
 #gh.GH_ComponentServer


### PR DESCRIPTION
"Ladybug Export" component finds default folder for .ghuser files:

UOFolder = "C:\Users\" + os.getenv("USERNAME") + "\AppData\Roaming\Grasshopper\UserObjects\"

Wind XP does not have the "Roaming" folder. So for Win XP the path is different. Maybe we could try this instead:

UOFolder = gh.GH_ComponentServer.GHUser_AppDataDirectory
