### PR TITLE
Address missing Tls12 protocol preventing ladybug flying on MacOS

### DIFF
--- a/src/ladybug_ladybug.py
+++ b/src/ladybug_ladybug.py
@@ -60,7 +60,11 @@ import sys
 import os
 import System.Threading.Tasks as tasks
 import System
-System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12
+try:
+    System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12
+except AttributeError:
+    # Ignore the lack of the Tls12 on MacOS .NET Core; else component wont fly
+    pass
 import time
 from itertools import chain
 import datetime


### PR DESCRIPTION
Apologies, I couldn't find any where in the documentation that lists whether MacOS is officially supported on the legacy plugin. If that's not the case feel free to reject this PR.

This issue is with the legacy version of the plugin LB 0.0.66 and HB 0.0.63 downloaded from Food4Rhino. Rhino 5.4.1 for Mac and GH 0.9.0080. I've reproduced it on several similar setups.

Placing the `ladybug_ladybug` component on a blank canvas yields an exception "'type' object has no attribute Tls12" on MacOS. This is due to line 63 of the source:

`System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12`

...because I assume that API isn't available to .NET Core on MacOS. However removing that line (or catching it in this manner) allows ladybug to fly correctly. 

Thanks again Mostapha and Chris for your work in maintaining and developing ladybug tools as OSS!