### PR TITLE
Revised a description about input:'_orientation_'.

### DIFF
--- a/src/Ladybug_Separate By Normal.py
+++ b/src/Ladybug_Separate By Normal.py
@@ -23,7 +23,7 @@ Provided by Ladybug 0.0.66
         _geometry: Geometry for which facades will be selected.  Geometry must be either a Brep, a Mesh or a list of Breps or Meshes.
         _maxUpDecAngle_: Maximum normal declination angle from ZAxis that should be still considerd up
         _maxDownDecAngle_: Maximum normal declination angle from ZAxis that should be still considerd down
-        _orientation_: A number between 0 and 8 for desired orientation. 0 = North, 1 = NE, 2 = East, ... 7 = NW, 8 = Roof. Default is South.
+        _orientation_: A number between 0 and 9 for desired orientation. 0 = North, 1 = NE, 2 = East, ... 7 = NW, 8 = Roof, 9 = Floor. Default is South.
         _plusDeg_: Angle in degrees for deviation from _orientation. Default = 23. For selecting all vertical orientations give 359 for this input and 0 for the _minusDeg_ (or viceversa)
         _minusDeg_: Angle in degrees for deviation from _orientation. Default = 23. For selecting all vertical orientations give 359 for this input and 0 for the _plusDeg_ (or viceversa)
     Returns:


### PR DESCRIPTION
'_orientation_' input's description says "A number between 0 and 9 ...".
But, judging from a whole sentences, a correct range of value accepted as '_orientation_' input is probably integers between 0 and 9.